### PR TITLE
Fix code scanning alert #176: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/zlib/contrib/java/jzlib-1.1.2/src/main/java/com/jcraft/jzlib/Deflate.java
+++ b/src/zlib/contrib/java/jzlib-1.1.2/src/main/java/com/jcraft/jzlib/Deflate.java
@@ -253,9 +253,9 @@ final class Deflate implements Cloneable {
   // Stop searching when current match exceeds this
   int nice_match;
 
-  short[] dyn_ltree;       // literal and length tree
-  short[] dyn_dtree;       // distance tree
-  short[] bl_tree;         // Huffman tree for bit lengths
+  int[] dyn_ltree;       // literal and length tree
+  int[] dyn_dtree;       // distance tree
+  int[] bl_tree;         // Huffman tree for bit lengths
 
   Tree l_desc=new Tree();  // desc for literal tree
   Tree d_desc=new Tree();  // desc for distance tree


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/176](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/176)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
