### PR TITLE
Fix code scanning alert #923: Wrong type of arguments to formatting function

### DIFF
--- a/src/gdb/tracepoint.c
+++ b/src/gdb/tracepoint.c
@@ -1299,7 +1299,7 @@ collect_symbol(struct collection_list *collect,
       offset = SYMBOL_VALUE (sym);
       if (info_verbose)
 	{
-	  printf_filtered ("LOC_BASEREG %s: collect %ld bytes at offset ",
+	  printf_filtered ("LOC_BASEREG %s: collect %lu bytes at offset ",
 			   DEPRECATED_SYMBOL_NAME (sym), len);
 	  printf_vma (offset);
 	  printf_filtered (" from basereg %d\n", reg);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/923](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/923)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
