### PR TITLE
Fix code scanning alert #921: Wrong type of arguments to formatting function

### DIFF
--- a/src/gdb/tracepoint.c
+++ b/src/gdb/tracepoint.c
@@ -1273,7 +1273,7 @@ collect_symbol(struct collection_list *collect,
       offset = 0;
       if (info_verbose)
 	{
-	  printf_filtered("LOC_REGPARM_ADDR %s: Collect %ld bytes at offset ",
+	  printf_filtered("LOC_REGPARM_ADDR %s: Collect %lu bytes at offset ",
 			  DEPRECATED_SYMBOL_NAME(sym), len);
 	  printf_vma(offset);
 	  printf_filtered(" from reg %d\n", reg);

--- a/src/gdb/tracepoint.c
+++ b/src/gdb/tracepoint.c
@@ -1274,7 +1274,7 @@ collect_symbol(struct collection_list *collect,
       if (info_verbose)
 	{
 	  printf_filtered("LOC_REGPARM_ADDR %s: Collect %lu bytes at offset ",
-			  DEPRECATED_SYMBOL_NAME(sym), len);
+			  DEPRECATED_SYMBOL_NAME(sym), (unsigned long)len);
 	  printf_vma(offset);
 	  printf_filtered(" from reg %d\n", reg);
 	}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/921](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/921)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
