### PR TITLE
Fix code scanning alert #920: Wrong type of arguments to formatting function

### DIFF
--- a/src/gdb/tracepoint.c
+++ b/src/gdb/tracepoint.c
@@ -1261,7 +1261,7 @@ collect_symbol(struct collection_list *collect,
       offset = (frame_offset + SYMBOL_VALUE(sym));
       if (info_verbose)
 	{
-	  printf_filtered("LOC_LOCAL %s: Collect %ld bytes at offset ",
+	  printf_filtered("LOC_LOCAL %s: Collect %lu bytes at offset ",
 			  DEPRECATED_SYMBOL_NAME(sym), len);
 	  printf_vma(offset);
 	  printf_filtered(" from frame ptr reg %d\n", reg);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/920](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/920)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
