### PR TITLE
Fix code scanning alert #918: Wrong type of arguments to formatting function

### DIFF
--- a/src/gdb/tracepoint.c
+++ b/src/gdb/tracepoint.c
@@ -1232,7 +1232,7 @@ collect_symbol(struct collection_list *collect,
 	  char tmp[40];
 
 	  snprintf_vma(tmp, sizeof(tmp), offset);
-	  printf_filtered("LOC_STATIC %s: collect %ld bytes at %s.\n",
+	  printf_filtered("LOC_STATIC %s: collect %zu bytes at %s.\n",
 			  DEPRECATED_SYMBOL_NAME(sym), len,
 			  tmp /* address */);
 	}


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/918](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/918)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
