### PR TITLE
Fix code scanning alert no. 692: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/valarith.c
+++ b/src/gdb/valarith.c
@@ -716,7 +716,7 @@ value_concat (struct value *arg1, struct value *arg2)
 	{
 	  count = longest_to_int (value_as_long (inval1));
 	  inval2len = TYPE_LENGTH (type2);
-	  ptr = (char *) alloca (count * inval2len);
+	  ptr = (char *) alloca ((unsigned long)count * inval2len);
 	  if (TYPE_CODE (type2) == TYPE_CODE_CHAR)
 	    {
 	      inchar = (char) unpack_long (type2,

--- a/src/gdb/valarith.c
+++ b/src/gdb/valarith.c
@@ -716,7 +716,7 @@ value_concat (struct value *arg1, struct value *arg2)
 	{
 	  count = longest_to_int (value_as_long (inval1));
 	  inval2len = TYPE_LENGTH (type2);
-	  ptr = (char *) alloca ((unsigned long)count * inval2len);
+	  ptr = (char *)alloca((size_t)count * inval2len);
 	  if (TYPE_CODE (type2) == TYPE_CODE_CHAR)
 	    {
 	      inchar = (char) unpack_long (type2,


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/692](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/692)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `unsigned long` before performing the multiplication. This way, the multiplication will be done in the `unsigned long` type, which has a larger range and can accommodate larger values without overflow.

The specific change involves casting `count` to `unsigned long` before the multiplication on line 719.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
