### PR TITLE
Fix code scanning alert no. 694: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/valprint.c
+++ b/src/gdb/valprint.c
@@ -1215,11 +1215,11 @@ val_print_string(CORE_ADDR addr, int len, int width, struct ui_file *stream)
         nfetch = (unsigned int)min(chunksize, (fetchlimit - bufsize));
 
         if (buffer == NULL)
-          buffer = (char *)xmalloc(nfetch * width);
+          buffer = (char *)xmalloc((size_t)nfetch * width);
         else
           {
             discard_cleanups(old_chain);
-            buffer = (char *)xrealloc(buffer, (nfetch + bufsize) * width);
+            buffer = (char *)xrealloc(buffer, ((size_t)nfetch + bufsize) * width);
           }
 
         old_chain = make_cleanup(xfree, buffer);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/694](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/694)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which is typically larger than `unsigned int` and can hold larger values.

**Detailed Steps:**
1. Locate the multiplication `nfetch * width` on line 1218.
2. Cast `nfetch` to `size_t` before the multiplication to ensure the operation is performed in the `size_t` type.
3. Ensure that the cast is applied consistently in similar contexts within the same function to maintain code consistency and prevent similar issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
