### PR TITLE
Fix code scanning alert no. 2803: Incomplete string escaping or encoding

### DIFF
--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -3533,7 +3533,7 @@ Object.extend(Selector, {
     },
     pseudo: function (a) {
       if (a[6]) {
-        a[6] = a[6].replace(/"/g, '\\"');
+        a[6] = a[6].replace(/\\/g, '\\\\').replace(/"/g, '\\"');
       }
       return new Template(
         'n = h.pseudo(n, "#{1}", "#{6}", r, c); c = false;',


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2803](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2803)

To fix the problem, we need to ensure that backslashes are also escaped in addition to double quotes. This can be achieved by using a regular expression with the global flag to replace all occurrences of backslashes and double quotes. 

The best way to fix this without changing existing functionality is to modify the `replace` method to handle both backslashes and double quotes. We will use a regular expression to match both characters and replace them accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
