### PR TITLE
Fix code scanning alert no. 693: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/valprint.c
+++ b/src/gdb/valprint.c
@@ -1198,11 +1198,11 @@ val_print_string(CORE_ADDR addr, int len, int width, struct ui_file *stream)
 
   if (len > 0)
     {
-      buffer = (char *)xmalloc(len * width);
+      buffer = (char *)xmalloc((size_t)len * width);
       bufptr = buffer;
       old_chain = make_cleanup(xfree, buffer);
 
-      nfetch = (partial_memory_read(addr, bufptr, (len * width), &errcode)
+      nfetch = (partial_memory_read(addr, bufptr, ((size_t)len * width), &errcode)
                 / width);
       addr += (nfetch * width);
       bufptr += (nfetch * width);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/693](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/693)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type before converting the result to `size_t`. This can be achieved by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the `size_t` type, which is typically larger than `int` and can hold larger values without overflow.

Specifically, we will:
1. Cast `len` to `size_t` before multiplying it by `width` on line 1201.
2. Similarly, cast `len` to `size_t` before multiplying it by `width` on line 1205.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
