### PR TITLE
Fix code scanning alert no. 2802: Incomplete string escaping or encoding

### DIFF
--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -3311,7 +3311,7 @@ var Selector = Class.create({
         if (a !== document) {
           var d = a.id,
             f = $(a).identify();
-          f = f.replace(/([\.:])/g, "\\$1");
+          f = f.replace(/([\\\.:])/g, "\\$1");
           c = "#" + f + " " + c;
         }
         b = $A(a.querySelectorAll(c)).map(Element.extend);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2802](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2802)

To fix the problem, we need to ensure that all special characters, including backslashes, are properly escaped in the string `f` before it is used in the CSS selector. The best way to achieve this is to use a regular expression with the global flag to replace all occurrences of special characters, including backslashes.

We will modify the `replace` method to include backslashes in the set of characters to be escaped. This can be done by using a regular expression that matches both the existing special characters and backslashes, and then replacing them with their escaped versions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
