### PR TITLE
Fix code scanning alert no. 2801: Incomplete string escaping or encoding

### DIFF
--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -558,7 +558,7 @@ Object.extend(
           return String.specialChar[character];
         }
         return "\\u00" + character.charCodeAt().toPaddedString(2, 16);
-      });
+      }).replace(/\\/g, "\\\\");
       if (useDoubleQuotes) {
         return '"' + escapedString.replace(/"/g, '\\"') + '"';
       }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2801](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2801)

To fix the problem, we need to ensure that backslashes are properly escaped in the `inspect` function. This can be done by adding an additional replacement step to escape backslashes before handling single or double quotes. The best way to fix this without changing existing functionality is to modify the `inspect` function to include a step that replaces backslashes with double backslashes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
