### PR TITLE
Fix code scanning alert no. 2794: Inefficient regular expression

### DIFF
--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -460,7 +460,7 @@ Object.extend(
       return this.replace(/^\s+/, "").replace(/\s+$/, "");
     }
     function stripTags() {
-      return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^<>"'\s]+)+)?>|<\/\w+>/gi, "");
+      return this.replace(/<\w+(?:\s+(?:"[^"]*"|'[^']*'|[^<>"'\s]+))*\s*>|<\/\w+>/gi, "");
     }
     function stripScripts() {
       return this.replace(new RegExp(Prototype.ScriptFragment, "img"), "");

--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -460,7 +460,7 @@ Object.extend(
       return this.replace(/^\s+/, "").replace(/\s+$/, "");
     }
     function stripTags() {
-      return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^<>"']+)+)?>|<\/\w+>/gi, "");
+      return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^<>"'\s]+)+)?>|<\/\w+>/gi, "");
     }
     function stripScripts() {
       return this.replace(new RegExp(Prototype.ScriptFragment, "img"), "");

--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -460,7 +460,7 @@ Object.extend(
       return this.replace(/^\s+/, "").replace(/\s+$/, "");
     }
     function stripTags() {
-      return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>])+)?>|<\/\w+>/gi, "");
+      return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^<>"']+)+)?>|<\/\w+>/gi, "");
     }
     function stripScripts() {
       return this.replace(new RegExp(Prototype.ScriptFragment, "img"), "");


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2794](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2794)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. The sub-expression `("[^"]*"|'[^']*'|[^>])+` can be rewritten to avoid the ambiguity between the alternatives. One way to achieve this is to use a non-capturing group and ensure that each alternative is mutually exclusive.

The best way to fix this without changing the existing functionality is to modify the regular expression in the `stripTags` function. Specifically, we can change the sub-expression to `("[^"]*"|'[^']*'|[^<>"']+)+`, which ensures that the third alternative does not match characters that can be matched by the first two alternatives.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
