### PR TITLE
Fix code scanning alert no. 2795: Inefficient regular expression

### DIFF
--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -4037,7 +4037,7 @@ Object.extend(Selector, {
   },
   split: function (b) {
     var a = [];
-    b.scan(/(([\w:.~>+()\-]+|#|\s+|\*|\[.*?\])+)\s*(,|$)/, function (c) {
+    b.scan(/((?:[\w:.~>+()\-]+|#|\s+|\*|\[[^\]]*?\])+)\s*(,|$)/, function (c) {
       a.push(c[1].strip());
     });
     return a;

--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -4037,7 +4037,7 @@ Object.extend(Selector, {
   },
   split: function (b) {
     var a = [];
-    b.scan(/(([\w#:.~>+()\s-]+|\*|\[.*?\])+)\s*(,|$)/, function (c) {
+    b.scan(/(([\w#:.~>+()\-]+|\s+|\*|\[.*?\])+)\s*(,|$)/, function (c) {
       a.push(c[1].strip());
     });
     return a;

--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -4037,7 +4037,7 @@ Object.extend(Selector, {
   },
   split: function (b) {
     var a = [];
-    b.scan(/(([\w#:.~>+()\-]+|\s+|\*|\[.*?\])+)\s*(,|$)/, function (c) {
+    b.scan(/(([\w:.~>+()\-]+|#|\s+|\*|\[.*?\])+)\s*(,|$)/, function (c) {
       a.push(c[1].strip());
     });
     return a;

--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -4037,7 +4037,7 @@ Object.extend(Selector, {
   },
   split: function (b) {
     var a = [];
-    b.scan(/((?:[\w:.~>+()\-]+|#|\s+|\*|\[[^\]]*?\])+)\s*(,|$)/, function (c) {
+    b.scan(/((?:[\w:.~>+()\-]+|#|\s+|\*|\[[^\]]*?\])+?)\s*(,|$)/, function (c) {
       a.push(c[1].strip());
     });
     return a;

--- a/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
+++ b/src/contrib/doc/Apple/TN2124_MacOSX_Debugging_Magic_via_Chrome.webarchive/Technical Note TN2124  Mac OS X Debugging Magic_files/prototype.js
@@ -4037,7 +4037,7 @@ Object.extend(Selector, {
   },
   split: function (b) {
     var a = [];
-    b.scan(/((?:[\w:.~>+()\-]+|#|\s+|\*|\[[^\]]*?\])+?)\s*(,|$)/, function (c) {
+    b.scan(/((?:[^\s,]+|#|\s+|\*|\[[^\]]*?\])+?)\s*(,|$)/, function (c) {
       a.push(c[1].strip());
     });
     return a;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2795](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2795)

To fix the problem, we need to modify the regular expression to remove the ambiguity that can lead to exponential backtracking. Specifically, we should ensure that the character class does not contain overlapping sets of characters that can match the same input in multiple ways. 

In this case, we can replace the ambiguous character class `[\w#:.~>+()\s-]` with a more precise set of characters that avoids overlap. For example, we can separate the whitespace characters from the other characters to ensure that each character in the input string is matched in a deterministic way.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
