### PR TITLE
Fix code scanning alert no. 2621: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/symfile.c
+++ b/src/gdb/symfile.c
@@ -5543,7 +5543,7 @@ simple_overlay_update_1(struct obj_section *osect)
 	&& (cache_ovly_table[i][LMA] == bfd_section_lma(obfd, bsect))
 	&& (cache_ovly_table[i][SIZE] == size))
       {
-	read_target_long_array((cache_ovly_table_base + i * TARGET_LONG_BYTES),
+	read_target_long_array((cache_ovly_table_base + (unsigned long)i * TARGET_LONG_BYTES),
                                (unsigned int *)cache_ovly_table[i], 4);
 	if ((cache_ovly_table[i][VMA] == bfd_section_vma(obfd, bsect))
 	    && (cache_ovly_table[i][LMA] == bfd_section_lma(obfd, bsect))


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2621](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2621)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to `unsigned long` before performing the multiplication. This way, the multiplication will be done in the `unsigned long` type, which has a larger range and can accommodate larger results without overflowing.

- **General Fix**: Cast one of the operands to `unsigned long` before the multiplication.
- **Detailed Fix**: In the file `src/gdb/symfile.c`, locate the line `i * TARGET_LONG_BYTES` and change it to `(unsigned long)i * TARGET_LONG_BYTES`.
- **Specific Changes**: Modify line 5546 to cast `i` to `unsigned long` before the multiplication.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
