### PR TITLE
Fix code scanning alert no. 2620: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/fix-and-continue.c
+++ b/src/gdb/fix-and-continue.c
@@ -1242,7 +1242,7 @@ find_and_parse_nonlazy_ptr_sect(struct fixinfo *cur,
         continue;
 
       (*indirect_entries)[actual_entry_count].addr =
-                         indirect_ptr_section_start + i * TARGET_ADDRESS_BYTES;
+                         indirect_ptr_section_start + (CORE_ADDR)i * TARGET_ADDRESS_BYTES;
       (*indirect_entries)[actual_entry_count].value = destination_address;
       (*indirect_entries)[actual_entry_count].new_sym = NULL;
       (*indirect_entries)[actual_entry_count].new_msym = NULL;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2620](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2620)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be achieved by casting one of the operands to the larger type before performing the multiplication. In this case, we will cast `i` to `CORE_ADDR` before multiplying it by `TARGET_ADDRESS_BYTES`.

- **General Fix**: Cast one of the operands to the larger type before performing the multiplication.
- **Detailed Fix**: In the file `src/gdb/fix-and-continue.c`, on line 1245, cast `i` to `CORE_ADDR` before multiplying it by `TARGET_ADDRESS_BYTES`.
- **Specific Changes**: Modify the line `(*indirect_entries)[actual_entry_count].addr = indirect_ptr_section_start + i * TARGET_ADDRESS_BYTES;` to `(*indirect_entries)[actual_entry_count].addr = indirect_ptr_section_start + (CORE_ADDR)i * TARGET_ADDRESS_BYTES;`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
