### PR TITLE
Fix code scanning alert no. 2619: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/fix-and-continue.c
+++ b/src/gdb/fix-and-continue.c
@@ -1215,7 +1215,7 @@ find_and_parse_nonlazy_ptr_sect(struct fixinfo *cur,
                        xmalloc(sizeof(struct file_static_fixups)
                                * nl_symbol_ptr_count));
 
-  buf = (gdb_byte *)xmalloc(nl_symbol_ptr_count * TARGET_ADDRESS_BYTES);
+  buf = (gdb_byte *)xmalloc((size_t)nl_symbol_ptr_count * TARGET_ADDRESS_BYTES);
   wipe = make_cleanup(xfree, buf);
 
   /* The following code to read an array of ints from the target and convert


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2619](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2619)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. This can be done by casting one of the operands to `size_t` before performing the multiplication. This way, the multiplication will be done in the larger type, and the result will be correctly represented.

Specifically, we will cast `nl_symbol_ptr_count` to `size_t` before multiplying it by `TARGET_ADDRESS_BYTES` on line 1218. This ensures that the multiplication is performed using `size_t`, which is large enough to hold the result without overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
