### PR TITLE
Fix code scanning alert no. 687: Multiplication result converted to larger type

### DIFF
--- a/src/gdb/f-valprint.c
+++ b/src/gdb/f-valprint.c
@@ -290,8 +290,8 @@ f77_print_array_1(int nss, int ndimensions, struct type *type,
 	{
 	  fprintf_filtered(stream, "( ");
 	  f77_print_array_1((nss + 1), ndimensions, TYPE_TARGET_TYPE(type),
-			    (valaddr + (i * F77_DIM_OFFSET(nss))),
-			    (address + (i * F77_DIM_OFFSET(nss))),
+			    (valaddr + ((CORE_ADDR)i * F77_DIM_OFFSET(nss))),
+			    (address + ((CORE_ADDR)i * F77_DIM_OFFSET(nss))),
 			    stream, format, deref_ref, recurse, pretty, elts);
 	  fprintf_filtered(stream, ") ");
 	}
@@ -305,8 +305,8 @@ f77_print_array_1(int nss, int ndimensions, struct type *type,
 	   i++, (*elts)++)
 	{
 	  val_print(TYPE_TARGET_TYPE(type),
-		    (valaddr + i * F77_DIM_OFFSET(ndimensions)),
-                    0, (address + i * F77_DIM_OFFSET(ndimensions)),
+		    (valaddr + (CORE_ADDR)i * F77_DIM_OFFSET(ndimensions)),
+                    0, (address + (CORE_ADDR)i * F77_DIM_OFFSET(ndimensions)),
 		    stream, format, deref_ref, recurse, pretty);
 
 	  if (i != (F77_DIM_SIZE(nss) - 1))


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/687](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/687)

To fix the problem, we need to ensure that the multiplication is performed using the larger type before the multiplication occurs. This can be achieved by casting one of the operands to the larger type (`CORE_ADDR`) before performing the multiplication. This way, the multiplication will be done in the larger type, preventing overflow.

Specifically, we will cast `i` to `CORE_ADDR` before multiplying it with `F77_DIM_OFFSET(ndimensions)` on lines 293, 294, 308, and 309.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
