### PR TITLE
Fix code scanning alert no. 470: Multiplication result converted to larger type

### DIFF
--- a/macsbug/MacsBug_screen.c
+++ b/macsbug/MacsBug_screen.c
@@ -173,17 +173,17 @@ void screen_init(int top, int left, int bottom, int right)
     max_y = max_rows;				/* this many rows			*/
     max_x = max_cols + (10 * max_cols);		/* worse possible case for width	*/
 
-    screen       = gdb_malloc(max_y * max_x);	/* allocate the screen buffers...	*/
-    prev_screen  = gdb_malloc(max_y * max_x);
+    screen       = gdb_malloc((size_t)max_y * max_x);	/* allocate the screen buffers...	*/
+    prev_screen  = gdb_malloc((size_t)max_y * max_x);
 
     row_len	 = gdb_malloc(max_y * sizeof(int)); /* allocate the row size arrays...	*/
     prev_row_len = gdb_malloc(max_y * sizeof(int));
 
-    memset(screen,      ' ', max_y * max_x);	/* init the screens to all blanks...	*/
-    memset(prev_screen, ' ', max_y * max_x);
+    memset(screen,      ' ', (size_t)max_y * max_x);	/* init the screens to all blanks...	*/
+    memset(prev_screen, ' ', (size_t)max_y * max_x);
 
-    memset(row_len,     0, max_y * sizeof(int));/* init the row sizes to all 0's	*/
-    memset(prev_row_len,0, max_y * sizeof(int));
+    memset(row_len,     0, (size_t)max_y * sizeof(int));/* init the row sizes to all 0's	*/
+    memset(prev_row_len,0, (size_t)max_y * sizeof(int));
 
     cursor_y = bottom;				/* position the cursor just in case	*/
     cursor_x = left;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/470](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/470)

To fix the problem, we need to ensure that the multiplication is performed using a larger integer type to prevent overflow. We can cast one of the operands to `size_t` before performing the multiplication. This will ensure that the multiplication is done using the larger type, thus avoiding overflow.

The specific changes required are:
1. Cast `max_y` to `size_t` before multiplying it with `max_x` in the `memset` function calls.
2. Similarly, cast `max_y` to `size_t` before multiplying it with `max_x` in the `gdb_malloc` function calls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
