### PR TITLE
Fix code scanning alert no. 686: Redundant null check due to previous dereference

### DIFF
--- a/src/gdb/scm-exp.c
+++ b/src/gdb/scm-exp.c
@@ -503,9 +503,7 @@ scm_parse(void)
   write_exp_string(str);
   write_exp_elt_opcode(OP_EXPRSTRING);
 #else
-  if (start == NULL) {
-    ; /* ??? */
-  }
+  /* Removed redundant null check for start */
 #endif /* USE_EXPRSTRING */
   return 0;
 }


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/686](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/686)

To fix the problem, we should remove the redundant null check on `start` on line 506. This will clean up the code and avoid unnecessary checks, as the dereference of `lexptr` ensures that `start` cannot be `NULL`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
