### PR TITLE
Fix code scanning alert no. 683: Suspicious add with sizeof

### DIFF
--- a/src/gdb/solib-frv.c
+++ b/src/gdb/solib-frv.c
@@ -139,8 +139,8 @@ fetch_loadmap (CORE_ADDR ldmaddr)
   memcpy (ext_ldmbuf, &ext_ldmbuf_partial, sizeof ext_ldmbuf_partial);
 
   /* Read the rest of the loadmap from the target: */
-  if (target_read_memory((ldmaddr + sizeof(ext_ldmbuf_partial)),
-                         (gdb_byte *)(ext_ldmbuf + sizeof(ext_ldmbuf_partial)),
+  if (target_read_memory(((gdb_byte *)ldmaddr + sizeof(ext_ldmbuf_partial)),
+                         ((gdb_byte *)ext_ldmbuf + sizeof(ext_ldmbuf_partial)),
                          (ext_ldmbuf_size - sizeof(ext_ldmbuf_partial))))
     {
       /* Failed to read rest of the loadmap: */


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/683](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/683)

To fix the problem, we need to ensure that the pointer arithmetic is done correctly. Instead of adding `sizeof(ext_ldmbuf_partial)` to the pointer, we should add the number of elements. This can be achieved by casting the pointer to a `gdb_byte *` type before performing the arithmetic. This way, the arithmetic will be done in terms of bytes, which is the intended behavior.

- Change the pointer arithmetic on line 143 to cast the pointer to `gdb_byte *` before adding the offset.
- Ensure that the rest of the code remains unchanged to maintain existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
