### PR TITLE
Potential fix for code scanning alert no. 3094: Redundant null check due to previous dereference

### DIFF
--- a/src/gdb/gnu-v2-abi.c
+++ b/src/gdb/gnu-v2-abi.c
@@ -281,8 +281,7 @@ gnuv2_value_rtti_type (struct value *v, int *full, int *top, int *using_enc)
             }
           else
             {
-              if (full)
-                *full = 1;
+              *full = 1;
             }
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3094](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3094)

To fix this without changing functionality, remove the redundant `if (full)` check at line 284 and assign directly to `*full` in that branch, because reaching that point already implies `full != NULL` from line 270’s condition.

Best single change in `src/gdb/gnu-v2-abi.c`:
- In the block under `if ((TYPE_N_BASECLASSES(rtti_type) > 1) && full && ((*full) != 1))`, inside the `else` branch of `if (TYPE_LENGTH(rtti_type) > TYPE_LENGTH(known_type))`, replace:
  - `if (full) *full = 1;`
  with:
  - `*full = 1;`

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
