### PR TITLE
Potential fix for code scanning alert no. 3119: Redundant null check due to previous dereference

### DIFF
--- a/src/gdb/gnu-v2-abi.c
+++ b/src/gdb/gnu-v2-abi.c
@@ -276,8 +276,7 @@ gnuv2_value_rtti_type (struct value *v, int *full, int *top, int *using_enc)
         {
           if (TYPE_LENGTH(rtti_type) > TYPE_LENGTH(known_type))
             {
-              if (full)
-                *full = 0;
+              *full = 0;
             }
           else
             {


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3119](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3119)

General fix: when a pointer has already been proven non-null (and dereferenced) on a path, remove later null checks on that same path, or move checks before dereference if safety is the concern.

Best fix here (no functional change): in `src/gdb/gnu-v2-abi.c`, inside the block starting at line 270, remove the nested `if (full)` and directly assign `*full = 0;` in the `TYPE_LENGTH(rtti_type) > TYPE_LENGTH(known_type)` branch. This is safe because entering the outer block already requires `full` to be non-null.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
