### PR TITLE
Potential fix for code scanning alert no. 3092: Redundant null check due to previous dereference

### DIFF
--- a/macsbug/gdb_plugin_support/gdb_set.c
+++ b/macsbug/gdb_plugin_support/gdb_set.c
@@ -334,7 +334,7 @@ static void define_set(char *theSetting, Gdb_Set_Funct sfunct, Gdb_Set_Type type
 	
 	helpInfo = gdb_malloc(strlen(help) + 1);
 	strcpy(helpInfo, help);
-    } else if (helpInfo && strncmp(helpInfo, "Set ", 4) != 0) {
+    } else if (strncmp(helpInfo, "Set ", 4) != 0) {
 	gdb_error("gdb_define_set() help info MUST begin with \"Set \" exactly");
 	return;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3092](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3092)

To fix this without changing behavior, simplify the `else if` condition at line 337 by removing `helpInfo &&`, since entering that branch already implies `helpInfo` is non-null and non-empty from the preceding `if (!helpInfo || !*helpInfo)`.

Best single change:
- In `macsbug/gdb_plugin_support/gdb_set.c`, replace:
  - `} else if (helpInfo && strncmp(helpInfo, "Set ", 4) != 0) {`
  with:
  - `} else if (strncmp(helpInfo, "Set ", 4) != 0) {`

No imports, new methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
