### PR TITLE
Potential fix for code scanning alert no. 2949: Wrong type of arguments to formatting function

### DIFF
--- a/src/gdb/remote-udi.c
+++ b/src/gdb/remote-udi.c
@@ -286,7 +286,7 @@ udi_open (char *name, int from_tty)
   if (from_tty)
     {
       printf_filtered ("Connected via UDI socket,\n\
- DFE-IPC version %x.%x.%x  TIP-IPC version %x.%x.%x  TIP version %x.%x.%x\n %s\n",
+ DFE-IPC version %lx.%lx.%lx  TIP-IPC version %lx.%lx.%lx  TIP version %lx.%lx.%lx\n %s\n",
 	       (DFEIPCId >> 8) & 0xf, (DFEIPCId >> 4) & 0xf, DFEIPCId & 0xf,
 	       (TIPIPCId >> 8) & 0xf, (TIPIPCId >> 4) & 0xf, TIPIPCId & 0xf,
 	       (TargetId >> 8) & 0xf, (TargetId >> 4) & 0xf, TargetId & 0xf,


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2949](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/2949)

The safest minimal fix is to make the format specifiers match the actual argument types passed to `printf_filtered`.

Best single fix here: in `src/gdb/remote-udi.c`, update the `%x` specifiers in the affected `printf_filtered` call (lines around 288–293) to `%lx`, so they correctly consume `unsigned long` values. This preserves behavior and output format while removing varargs type mismatch UB. No new methods/imports/definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
