### PR TITLE
Potential fix for code scanning alert no. 3120: Wrong type of arguments to formatting function

### DIFF
--- a/src/gdb/gnu-regex.c
+++ b/src/gdb/gnu-regex.c
@@ -863,7 +863,7 @@ print_partial_compiled_pattern(unsigned char *start, unsigned char *end)
       putchar ('\n');
     }
 
-  printf ("%d:\tend of pattern.\n", p - start);
+  printf ("%ld:\tend of pattern.\n", (long) (p - start));
 }
 
 void


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3120](https://github.com/cooljeanius/apple-gdb-1824/security/code-scanning/3120)

The fix is to make the format specifier match the type of `p - start`.

Best minimal fix (no functional change): in `src/gdb/gnu-regex.c` at the `printf` on line 866, change `%d` to `%ld` and cast the pointer difference to `long` to make the type explicit and silence mismatches portably for this code’s expected type resolution.

Change needed:
- File: `src/gdb/gnu-regex.c`
- Region: `print_partial_compiled_pattern` tail where `"end of pattern"` is printed.
- Edit: `printf ("%d:\tend of pattern.\n", p - start);` → `printf ("%ld:\tend of pattern.\n", (long) (p - start));`
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
